### PR TITLE
Move to Gulp 4, fix require path in 06

### DIFF
--- a/experiments/06 - shape studies/js/entry.js
+++ b/experiments/06 - shape studies/js/entry.js
@@ -2,7 +2,7 @@ let Node = require('../../../core/Node'),
     Path = require('../../../core/Path'),
     World = require('../../../core/World'),
     Settings = require('./Settings'),
-    overlap = require('../node_modules/polygon-overlap');
+    overlap = require('../../../node_modules/polygon-overlap');
 
 let world;
 

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -82,16 +82,15 @@ gulp.task('build:js', () => {
 });
 
 // Build all
-gulp.task('build', ['clean', 'build:js']);
-
+gulp.task('build', gulp.series(gulp.parallel('clean', 'build:js')));
 
 //=============
 //  WATCH
 //=============
 
 gulp.task('watch', () => {
-  gulp.watch(globs.allJs, ['build']);
-  gulp.watch(globs.allHtml, ['build']);
+  gulp.watch(globs.allJs, gulp.parallel('build'));
+  gulp.watch(globs.allHtml, gulp.parallel('build'));
 });
 
 
@@ -119,4 +118,4 @@ gulp.task('open', () => {
 //  DEFAULT
 //=============
 
-gulp.task('default', ['build', 'serve', 'open', 'watch']);
+gulp.task('default', gulp.series(gulp.parallel('build', 'serve', 'open', 'watch')));

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "browserify": "^16.5.1",
     "del": "^3.0.0",
     "docdash": "^1.2.0",
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "gulp-autoprefixer": "^5.0.0",
     "gulp-babel": "^8.0.0",
     "gulp-clean-css": "^3.10.0",
@@ -26,6 +26,7 @@
     "gulp-uglify": "^3.0.2",
     "jsdoc": "^3.6.4",
     "merge-stream": "^1.0.1",
+    "polygon-overlap": "^1.0.5",
     "vinyl-buffer": "^1.0.1",
     "vinyl-source-stream": "^2.0.0",
     "yargs": "^12.0.5"


### PR DESCRIPTION
Newer versions of node no longer work with Gulp 3.x.... this brings you to Gulp 4, plus fixes a require path in experiment 6.

Thanks for creating this, I think my work productivity may be impacted for a few days 🥇 